### PR TITLE
Limit displayed search results to maximum of 10

### DIFF
--- a/app/(dashboard)/go-compare/search-history/page.tsx
+++ b/app/(dashboard)/go-compare/search-history/page.tsx
@@ -137,7 +137,7 @@ const SearchHistory = () => {
                                                 )}
                                             </div>
                                         </td>
-                                        <td className="px-4 py-3">{record.results}</td>
+                                        <td className="px-4 py-3">{Math.min(record.results, 10)}</td>
                                     </tr>
                                 ))}
                             </tbody>


### PR DESCRIPTION
Updated the search history table to display a maximum of 10 results per record by using Math.min.