### PR TITLE
style(quick-search): update store link hover color and dev script

### DIFF
--- a/app/(dashboard)/go-compare/_components/QuickSearchTable.tsx
+++ b/app/(dashboard)/go-compare/_components/QuickSearchTable.tsx
@@ -126,7 +126,7 @@ function DraggableRow({
                   href={quickSearchProduct.product_url} 
                   target="_blank" 
                   rel="noopener noreferrer" 
-                  className="text-sm font-medium hover:underline"
+                  className="text-sm font-medium hover:text-[#18CB96] hover:underline"
                 >
                   {quickSearchProduct.store_name || 'Unknown Store'}
                 </a>
@@ -177,7 +177,7 @@ function DraggableRow({
                   href={productObj.scraped_product.product_url} 
                   target="_blank" 
                   rel="noopener noreferrer" 
-                  className="text-sm font-medium hover:underline"
+                  className="text-sm font-medium hover:text-[#18CB96] hover:underline"
                 >
                   {productObj.store?.name || 'Unknown Store'}
                 </a>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbo",
+    "dev": "next dev",
     "build": "next build --no-lint",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
- Change store link hover color from default to brand green (#18CB96) in QuickSearchTable component
- Update hover state styling for both quick search and product comparison store links
- Remove --turbo flag from dev script to improve build performance
- Enhance visual feedback when users hover over store name links